### PR TITLE
Improve color contrast

### DIFF
--- a/creator.html
+++ b/creator.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,7 +14,7 @@
     <div class="m-4 container">
         <h1>RosimInc's Nonogram Café</h1>
         <h2>Nonogram Creator</h2>
-        
+
         <div>
             <form id="creationForm">
                 <div class="m-2">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,7 +25,7 @@
         </div>
 
         <div id="nonoDiv"></div>
-        
+
         <div id="msgDiv" class="my-2 p-2 bg-success bg-opacity-10 border border-success rounded fw-bold"></div>
 
         <div id="instructions" class="p-2 bg-info bg-opacity-10 border border-info rounded">


### PR DESCRIPTION
Original reported here: https://www.steamgifts.com/go/comment/LutNd8a

> Some accessibility problems: the top buttons (undo, redo,...) in their disable state have a color contrast of 3,86; the giveaway link has a contrast ratio of 2,76. I suggest to increase the ratio to at least 4,5.

This patch will fix the color contrast of the giveaway link.
The color contrast of the disabled buttons is a Bootstrap issue.