### PR TITLE
Improve contrast and mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
             <h3>Instructions</h3>
             <ul>
                 <li>Fill squares so that groups of squares match the hints of that row/column</li>
-                <li>Groups must be separated by one or more empty squares</li><br>
+                <li>Groups must be separated by one or more empty squares</li>
+                <li>Once you fill all the cells correctly, the playing field will turn green, and below it you will see a secret message.</li><br>
                 <li>Click to fill a cell</li>
                 <li>Right-click to mark with an X that it cannot be filled</li>
                 <li>Click or right-click again to remove the marking</li>

--- a/index.html
+++ b/index.html
@@ -15,14 +15,16 @@
     <div class="m-4 container">
         <h1>RosimInc's Nonogram Café</h1>
 
-        <div id="buttons" class="my-2">
-            <button type="button" id="undoBtn" class="btn btn-primary">Undo</button>
-            <button type="button" id="redoBtn" class="btn btn-primary">Redo</button>
-            <button type="button" id="zoomInBtn" class="btn btn-primary">Zoom In</button>
-            <button type="button" id="zoomOutBtn" class="btn btn-primary">Zoom Out</button>
-            <button type="button" id="resetBtn" class="btn btn-primary">Reset</button>
-            <button type="button" id="createBtn" class="btn btn-secondary">Create Your Own!</button>
-        </div>
+        <div id="buttonContainer" class="my-2">
+            <div id="buttons" class="d-flex flex-wrap gap-2">
+              <button type="button" id="undoBtn" class="btn btn-primary">Undo</button>
+              <button type="button" id="redoBtn" class="btn btn-primary">Redo</button>
+              <button type="button" id="zoomInBtn" class="btn btn-primary">Zoom In</button>
+              <button type="button" id="zoomOutBtn" class="btn btn-primary">Zoom Out</button>
+              <button type="button" id="resetBtn" class="btn btn-primary">Reset</button>
+              <button type="button" id="createBtn" class="btn btn-secondary">Create Your Own!</button>
+            </div>
+          </div>
 
         <div id="nonoDiv"></div>
 

--- a/styles/nonogram.css
+++ b/styles/nonogram.css
@@ -7,3 +7,22 @@ body {
 #msgDiv {
     display: none;
 }
+
+#buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  
+  button {
+    padding: 10px 20px;
+    font-size: 1rem;
+    flex: 1 1 auto;
+  }
+  
+  @media (min-width: 768px) {
+    button {
+      flex: 0 0 auto;
+    }
+  }
+  

--- a/styles/nonogram.css
+++ b/styles/nonogram.css
@@ -26,3 +26,15 @@ body {
     }
   }
   
+  .btn-primary {
+    background-color: #0049a3; 
+    color: #ffffff;    
+    border-color: #0049a3; 
+  }
+ 
+  .btn-primary:disabled, .btn-primary.disabled {
+    background-color: #5C7A99; 
+    color: #ffffff;    
+    border-color: #5C7A99; 
+    opacity: 1;
+  }


### PR DESCRIPTION
Hi, @RosimInc !
Finally had the time to brush up previous PR. 

Original reported by **ngoclong19** [here:](https://www.steamgifts.com/go/comment/LutNd8a)

```
Some accessibility problems: the top buttons (undo, redo,...) in their disable state have a color contrast of 3,86. 
I suggest to increase the ratio to at least 4,5.
The color contrast of the disabled buttons is a Bootstrap issue.
```

Now it's fixed. Used different color schemas: 
primary is now 8.46 (was 5.83) : [link](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=0049A3)
disabled is now 4.46 (was 3.86): [link](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=0049A3)

And there were some improvements from me, such as: 
- Clarification of instructions (added requirement for end of the game, and what will happened next). This clarification will improve user experience, especially, playing for the first time.
- Add adaptive mobile layout for buttons. 

Anyway, thank you for such a good tool! 