### PR TITLE
Implement a tooltip assist to decrease counting issues in big nonos

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
             <h3>Instructions</h3>
             <ul>
                 <li>Fill squares so that groups of squares match the hints of that row/column</li>
-                <li>Groups must be separated by one or more empty squares</li><br>
+                <li>Groups must be separated by one or more empty squares</li>
+                <li>Once you fill all the cells correctly, the playing field will turn green, and below it you will see a secret message.</li><br>
                 <li>Click to fill a cell</li>
                 <li>Right-click to mark with an X that it cannot be filled</li>
                 <li>Click or right-click again to remove the marking</li>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,9 @@
             <button type="button" id="createBtn" class="btn btn-secondary">Create Your Own!</button>
         </div>
 
-        <div id="nonoDiv"></div>
+        <div id="nonoDiv">
+            <div class="cell-counter-tooltip"></div>
+        </div>
 
         <div id="msgDiv" class="my-2 p-2 bg-success bg-opacity-10 border border-success rounded fw-bold"></div>
 

--- a/index.html
+++ b/index.html
@@ -15,14 +15,16 @@
     <div class="m-4 container">
         <h1>RosimInc's Nonogram Café</h1>
 
-        <div id="buttons" class="my-2">
-            <button type="button" id="undoBtn" class="btn btn-primary">Undo</button>
-            <button type="button" id="redoBtn" class="btn btn-primary">Redo</button>
-            <button type="button" id="zoomInBtn" class="btn btn-primary">Zoom In</button>
-            <button type="button" id="zoomOutBtn" class="btn btn-primary">Zoom Out</button>
-            <button type="button" id="resetBtn" class="btn btn-primary">Reset</button>
-            <button type="button" id="createBtn" class="btn btn-secondary">Create Your Own!</button>
-        </div>
+        <div id="buttonContainer" class="my-2">
+            <div id="buttons" class="d-flex flex-wrap gap-2">
+              <button type="button" id="undoBtn" class="btn btn-primary">Undo</button>
+              <button type="button" id="redoBtn" class="btn btn-primary">Redo</button>
+              <button type="button" id="zoomInBtn" class="btn btn-primary">Zoom In</button>
+              <button type="button" id="zoomOutBtn" class="btn btn-primary">Zoom Out</button>
+              <button type="button" id="resetBtn" class="btn btn-primary">Reset</button>
+              <button type="button" id="createBtn" class="btn btn-secondary">Create Your Own!</button>
+            </div>
+          </div>
 
         <div id="nonoDiv"></div>
 

--- a/js/index.js
+++ b/js/index.js
@@ -54,6 +54,10 @@ const sketch = (p, id) => {
     let movesRedo = [];
     let ended = false;
 
+    let currentDragCount = 0;
+    let tooltip = document.querySelector('.cell-counter-tooltip');
+    let isDragging = false;
+
     p.setup = function() {
         canvas = p.createCanvas(500, 300);
         canvas.parent(document.getElementById('nonoDiv'));
@@ -207,6 +211,13 @@ const sketch = (p, id) => {
             p.line(col * cellSize, -maxVerHints * cellSize,
                 col * cellSize, numRows * cellSize);
         }
+
+        canvas.elt.addEventListener('mousemove', (e) => updateTooltip(e));
+        canvas.elt.addEventListener('touchmove', (e) => {
+            if(e.touches.length === 1) {
+                updateTooltip(e.touches[0]);
+            }
+        });
     }
 
     function drawHorHints() {
@@ -428,16 +439,40 @@ const sketch = (p, id) => {
     function setAction(action, eventInfo = null) {
         clearActions();
         actionEvent = eventInfo;
+        currentDragCount = 0;
+        isDragging = true;
         addAction(action);
     }
 
     function addAction(action) {
         apply(action);
         actions.push(action);
+        if(action.type === ACTION_TYPE.MARK_CELL && action.to !== CELL_MARK.EMPTY) {
+            currentDragCount++;
+            updateTooltip();
+          }
     }
+
+    function updateTooltip(event) {
+        if(isDragging && currentDragCount > 0) {
+          tooltip.style.opacity = '1';
+          tooltip.textContent = currentDragCount;
+          
+          if(event) {
+            tooltip.style.left = `${event.clientX + 15}px`;
+            tooltip.style.top = `${event.clientY + 15}px`;
+          }
+        } else {
+          tooltip.style.opacity = '0';
+        }
+      }
 
     function clearActions() {
         actionEvent = null;
+        isDragging = false;
+        currentDragCount = 0;
+        updateTooltip();
+        
         if(actions && actions.length > 0) {
             addUndo(actions);
         }

--- a/js/index.js
+++ b/js/index.js
@@ -447,7 +447,7 @@ const sketch = (p, id) => {
     function addAction(action) {
         apply(action);
         actions.push(action);
-        if(action.type === ACTION_TYPE.MARK_CELL && action.to !== CELL_MARK.EMPTY) {
+        if(action.type === ACTION_TYPE.MARK_CELL && action.to !== CELL_MARK.WHITE && action.to !== CELL_MARK.EMPTY) {
             currentDragCount++;
             updateTooltip();
           }

--- a/styles/nonogram.css
+++ b/styles/nonogram.css
@@ -7,3 +7,22 @@ body {
 #msgDiv {
     display: none;
 }
+
+#buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  
+  button {
+    padding: 10px 20px;
+    font-size: 1rem;
+    flex: 1 1 auto;
+  }
+  
+  @media (min-width: 768px) {
+    button {
+      flex: 0 0 auto;
+    }
+  }
+  

--- a/styles/nonogram.css
+++ b/styles/nonogram.css
@@ -26,3 +26,15 @@ body {
     }
   }
   
+  .btn-primary {
+    background-color: #0049a3; 
+    color: #ffffff;    
+    border-color: #0049a3; 
+  }
+ 
+  .btn-primary:disabled, .btn-primary.disabled {
+    background-color: #5C7A99; 
+    color: #ffffff;    
+    border-color: #5C7A99; 
+    opacity: 1;
+  }

--- a/styles/nonogram.css
+++ b/styles/nonogram.css
@@ -7,3 +7,17 @@ body {
 #msgDiv {
     display: none;
 }
+
+.cell-counter-tooltip {
+    position: absolute;
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+    z-index: 5;
+}


### PR DESCRIPTION
Hi again, @RosimInc !
Now it's time to add a cool UX feature - a tooltip assist! 
I came up with this after a few user posts about readability and counting issues. 

Original reported by **[drbeckett](https://www.steamgifts.com/user/drbeckett)** and **[timmyfromspace](https://www.steamgifts.com/user/timmyfromspace)** [here:](https://www.steamgifts.com/discussion/IJJwy/rosimincs-2025-nonogram-cafe-weeks-16-19-active-4-bonus-puzzles/search?page=4#81BCIub)

```
One suggestion I have is to have the marked cells with a different color, maybe blue? Because sometimes it's hard to see 
how many you marked, you have to look to the top or left side to see which line/paragraph is highlighted. 
If the color of the cell is different than the dividing lines it would be easier to notice each cell.
```
Also **[PoeticKatana](https://www.steamgifts.com/user/PoeticKatana)** reported another suggestion [here:](https://www.steamgifts.com/discussion/IJJwy/rosimincs-2025-nonogram-cafe-weeks-16-19-active-4-bonus-puzzles/search?page=5#2CCkuaB)

```
RosimInc, if I could make one visual improvement suggestion, it's to increase the contrast between filled squares and the grid. 
The combination of black fill and a black grid makes it a bit hard to count filled spaces. It's just a minor annoyance. 
Not a huge deal.
```

Now it's been fixed. Tooltip assist solves the contrast and counting issues. How does it look like? 
Now if you start to drag mouse it wiil be a small tooltip around the cursor:
![image](https://github.com/user-attachments/assets/2c0f2b5a-69dd-41f9-bac6-8ef955d490a3)

It will be very helpful for big nonos, where you should do many counts) 

Anyway, thank you for such a good tool! 